### PR TITLE
ember-modifier requires ember-auto-import

### DIFF
--- a/packages/ember-on-resize-modifier/package.json
+++ b/packages/ember-on-resize-modifier/package.json
@@ -40,6 +40,7 @@
     "*.hbs": "ember-template-lint"
   },
   "dependencies": {
+    "ember-auto-import": "^2.0.0",
     "ember-cli-babel": "^7.26.6",
     "ember-cli-htmlbars": "^5.7.1",
     "ember-modifier": "^3.2.7",


### PR DESCRIPTION
## Changes

At present, the the on resize modifier is not usable due to build time error about ember-auto-import not being a dependency.



## Ticket
<!--Add the link to the Jira ticket.-->

https://precisionnutrition.atlassian.net/browse/XX-123

## Testing Instructions
<!--Add some notes on how to review and test the changes.-->

- [ ] TODO

---

## Screenshots (Optional)



## Related PRs (Optional)

- 

---

### Author Checklist
<!--Your responsibilities as the Author-->

- Author wrote tests for the changes
- Selected a team in the Reviewers drop-down to auto-assign reviewers
- Selected one of the reviewers as the Assignee to be the primary reviewer
- (Optional) Explained any new third-party additions

### Reviewer Checklist
<!--Your responsibilities as a Reviewer and/or the Assignee-->

#### For the Reviewer(s)

- Read and understood the code change.
- Verified the changes are tested.
- Verified the code is feature flagged (if needed).

#### For the Assignee (all of the above plus...)

- Ran the code locally or on a staging server and verified it works.
- Approved all Percy changes (if needed)
