### PR TITLE
[DEPRECATION] Deprecate importing inject from @ember/service

### DIFF
--- a/packages/ember-on-resize-modifier/addon/modifiers/on-resize.js
+++ b/packages/ember-on-resize-modifier/addon/modifiers/on-resize.js
@@ -1,5 +1,5 @@
 import Modifier from 'ember-modifier';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { assert } from '@ember/debug';
 import { registerDestructor } from '@ember/destroyable';
 

--- a/packages/ember-resize-observer-service/README.md
+++ b/packages/ember-resize-observer-service/README.md
@@ -74,7 +74,7 @@ Here is a simplified example of [`{{on-resize}}`][on-resize-modifier] modifier u
 
 ```js
 import Modifier from 'ember-modifier';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 
 export default class OnResizeModifier extends Modifier {

--- a/packages/ember-resize-observer-service/tests/dummy/app/modifiers/on-resize.js
+++ b/packages/ember-resize-observer-service/tests/dummy/app/modifiers/on-resize.js
@@ -1,5 +1,5 @@
 import Modifier from 'ember-modifier';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { assert } from '@ember/debug';
 


### PR DESCRIPTION
[DEPRECATION] Deprecate importing inject from @ember/service. The export is renamed to service per [RFC #0752](https://rfcs.emberjs.com/id/0752-inject-service/).